### PR TITLE
Fix: Precommit config was searching nonexistent folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-repos:
-  - repo: local
-    files: ^signwriting/
+files: ^pose_evaluation/
+repos:  
+  - repo: local    
     hooks:
       - id: pylint
         name: pylint


### PR DESCRIPTION
Very small PR, I discovered the pre-commit config was searching for files in "signwriting", not "pose_evaluation".